### PR TITLE
Fix build error of sample

### DIFF
--- a/sample/app/build.gradle
+++ b/sample/app/build.gradle
@@ -24,7 +24,7 @@ android {
 }
 
 dependencies {
-    compile 'com.github.rettyeng:redux-kt:0.0.1-SNAPSHOT'
+    compile 'com.github.rettyeng:redux-kt:0.0.1+'
     compile fileTree(dir: 'libs', include: ['*.jar'])
     androidTestCompile('com.android.support.test.espresso:espresso-core:2.2.2', {
         exclude group: 'com.android.support', module: 'support-annotations'

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -18,6 +18,7 @@ allprojects {
     repositories {
         jcenter()
         mavenLocal()
+        maven { url 'https://jitpack.io' }
     }
 }
 


### PR DESCRIPTION
下記のビルドエラーを修正しました。

```
Error:(26, 13) Failed to resolve: com.github.rettyeng:redux-kt:0.0.1-SNAPSHOT
```

原因は

* ```0.0.1-SNAPSHOT```というタグがJitPackに存在しない
  * 恐らく、RettyのmavenLocalにのみ存在する？
* ```com.github.rettyeng:redux-kt```が見つからない
  * ```maven { url 'https://jitpack.io' }```が抜けていた
  * ~~恐らく、RettyのmavenLocalから引っ張っていたので社内では問題無かった？~~
    * ~~Retty内部ではmavenLocalが優先されると良いのですが~~
    * mavenLocalの事をよく知らずに書いてました…

と思います。